### PR TITLE
Fixed syntax error in 4leggedRobot.urdf

### DIFF
--- a/src/4leggedRobot.urdf
+++ b/src/4leggedRobot.urdf
@@ -21,7 +21,7 @@
         </geometry>
     </collision>
     <inertial>
-      <origin xyz="0.018 , 2.287E-04 , 0.01"/>
+      <origin xyz="0.018 2.287E-04 0.01"/>
       <mass value="1.248" />
       <inertia ixx="0.002" ixy="7.984E-08" ixz="-2.045E-04"
                               iyy="0.007" iyz="-2.383E-06"


### PR DESCRIPTION
The URDF was not parsing when I tried to load it in Rviz. This was the fix. However, the model loaded fine in PyBullet.
Thank you for the great model btw :D